### PR TITLE
Fix warnings in tests

### DIFF
--- a/test/io/fd.cc
+++ b/test/io/fd.cc
@@ -61,14 +61,14 @@ TEST(FdTest, OpenReadWriteClose)
     po6::io::fd fd;
     fd = open("/dev/zero", O_RDWR);
     char buf[4096];
-    fd.read(buf, 4096);
+    ASSERT_EQ(static_cast<ssize_t>(4096), fd.read(buf, 4096));
 
     for (int i = 0; i < 4096; ++i)
     {
         ASSERT_EQ(buf[i], '\0');
     }
 
-    fd.write(buf, 4096);
+    ASSERT_EQ(static_cast<ssize_t>(4096), fd.write(buf, 4096));
     fd.close();
 }
 

--- a/test/net/socket.cc
+++ b/test/net/socket.cc
@@ -66,17 +66,17 @@ TEST(SocketTest, ClientAndServer)
     ip.pack(&sa, &salen, INADDR_ANY);
 
     // Create the server.
-    server.bind(ip);
-    server.listen(10);
+    ASSERT_TRUE(server.bind(ip));
+    ASSERT_TRUE(server.listen(10));
 
     // Create the client.
     po6::net::location loc;
     ASSERT_TRUE(server.getsockname(&loc));
-    client.connect(loc);
+    ASSERT_TRUE(client.connect(loc));
 
     // Close down the connection.
-    client.shutdown(SHUT_RDWR);
-    server.shutdown(SHUT_RDWR);
+    ASSERT_TRUE(client.shutdown(SHUT_RDWR));
+    ASSERT_TRUE(server.shutdown(SHUT_RDWR));
     client.close();
     server.close();
 }


### PR DESCRIPTION
## Summary
- check return values in fd tests
- verify socket operations in socket tests

## Testing
- `make clean`
- `make check > /tmp/make_check.log 2>&1`
